### PR TITLE
Only show badges for common accounts in user list

### DIFF
--- a/app/views/components/pageflow/admin/user_account_badge_list.rb
+++ b/app/views/components/pageflow/admin/user_account_badge_list.rb
@@ -5,7 +5,7 @@ module Pageflow
 
       def build(user)
         ul class: 'badge_list' do
-          user.memberships.on_accounts.each do |membership|
+          user_accounts(user).each do |membership|
             build_badge(membership)
           end
 
@@ -15,11 +15,15 @@ module Pageflow
 
       private
 
+      def user_accounts(user)
+        user.memberships.on_accounts.accessible_by(current_ability)
+      end
+
       def build_badge(membership)
         li do
           if authorized?(:read, membership.entity)
             account_name_display = span(link_to(membership.entity.name,
-                                                admin_account_path(membership.entity)),
+                                                main_app.admin_account_path(membership.entity)),
                                         class: 'abbreviation')
           else
             account_name_display = span(membership.entity.name, class: 'abbreviation')

--- a/spec/views/components/pageflow/admin/user_account_badge_list_spec.rb
+++ b/spec/views/components/pageflow/admin/user_account_badge_list_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+module Pageflow
+  describe Admin::UserAccountBadgeList, type: :view_component do
+    it 'renders only accounts the current user is member of' do
+      current_user = create(:user)
+      user = create(:user)
+      common_account = create(:account, name: 'Common')
+      other_account = create(:account, name: 'Other')
+      create(:membership, user: current_user, entity: common_account, role: :manager)
+      create(:membership, user: user, entity: common_account)
+      create(:membership, user: user, entity: other_account)
+
+      allow(helper).to receive(:current_ability).and_return(Ability.new(current_user))
+      allow(helper).to receive(:authorized?).and_return(true)
+
+      render(user)
+
+      expect(rendered).to have_selector('li', text: /Common/)
+      expect(rendered).not_to have_selector('li', text: /Other/)
+    end
+  end
+end


### PR DESCRIPTION
Prevent display of badges for accounts the current user is not member of.
