### PR TITLE
Replace chromedriver-helper by webdrivers

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -155,7 +155,7 @@ Gem::Specification.new do |s|
 
   # Chrome Headless browser testing
   s.add_development_dependency 'selenium-webdriver', '~> 3.6.x'
-  s.add_development_dependency 'chromedriver-helper', '~> 2.1.x'
+  s.add_development_dependency 'webdrivers', '~> 4.0'
 
   # View abstraction fro integration testing
   s.add_development_dependency 'domino', '~> 0.7.0'

--- a/spec/support/config/capybara.rb
+++ b/spec/support/config/capybara.rb
@@ -1,7 +1,7 @@
 require 'capybara/rspec'
 require 'selenium-webdriver'
 require 'capybara/chromedriver/logger'
-require 'chromedriver-helper'
+require 'webdrivers/chromedriver'
 
 Capybara.register_driver :selenium_chrome_headless_no_sandbox do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new

--- a/spec/support/config/web_mock.rb
+++ b/spec/support/config/web_mock.rb
@@ -2,6 +2,7 @@ require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.before(:each) do
-    WebMock.disable_net_connect!(allow_localhost: true)
+    driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
+    WebMock.disable_net_connect!(allow_localhost: true, allow: driver_urls)
   end
 end


### PR DESCRIPTION
According to [1], chromedriver-helper is unmaintained. Its former
maintainer encourages using webdrivers [2].

As part of this change, we allow connections to update drivers in the
WebMock config. See [3] for details about this.

[1] https://github.com/flavorjones/chromedriver-helper#notice-this-gem-is-out-of-support-as-of-2019-03-31
[2] https://github.com/titusfortner/webdrivers
[3] https://github.com/titusfortner/webdrivers/issues/109

REDMINE-17242